### PR TITLE
[Bug Fix] Use http://retro.grooveshark instead of http://grooveshark.com

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -110,10 +110,10 @@ FORMS           += mainwindow.ui \
                    dlg_preferences.ui
 
 # Version infos
-VERSION          = 1.0.0
+VERSION          = 1.1.1
 DEFINES         += VERSION_MAJOR=1
 DEFINES         += VERSION_MINOR=1
-DEFINES         += VERSION_MICRO=0
+DEFINES         += VERSION_MICRO=1
 DEFINES         += VERSION_STATUS=\\\"\\\"
 
 

--- a/plugins/grooveshark/grooveshark.cpp
+++ b/plugins/grooveshark/grooveshark.cpp
@@ -58,7 +58,7 @@ bool GroovesharkPlugin::flashRequired()
 //---------------------------------------------------------
 QUrl GroovesharkPlugin::url() const
 {
-    return QUrl("http://grooveshark.com");
+    return QUrl("http://retro.grooveshark.com");
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Grooveshark has released a new version of their website, unfortunately it does not work well with QtWebKit (crash/freeze when browsing a large collection, completely unusable).

This commit also bumps the version to v1.1.1