### PR TITLE
Add support for fetching lyrics of the current song

### DIFF
--- a/app/forms/dlg_preferences.ui
+++ b/app/forms/dlg_preferences.ui
@@ -77,14 +77,14 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="pageInterface">
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <widget class="QGroupBox" name="groupBoxMinimizeToTray">
            <property name="title">
-            <string>Minimize to system tray</string>
+            <string>Minimi&amp;ze to system tray</string>
            </property>
            <property name="flat">
             <bool>false</bool>
@@ -135,6 +135,16 @@
              </layout>
             </item>
            </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkBoxAutoShowLyrics">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically show or hide the lyrics pane.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Automatically show lyrics pane</string>
+           </property>
           </widget>
          </item>
          <item>

--- a/app/forms/mainwindow.ui
+++ b/app/forms/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1113</width>
-    <height>712</height>
+    <width>871</width>
+    <height>699</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -471,13 +471,13 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1113</width>
+     <width>871</width>
      <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuApplication">
     <property name="title">
-     <string>Applicatio&amp;n</string>
+     <string>Appli&amp;cation</string>
     </property>
     <addaction name="actionSelect_service"/>
     <addaction name="actionPreferences"/>
@@ -506,7 +506,7 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
-     <string>V&amp;iew</string>
+     <string>&amp;View</string>
     </property>
     <addaction name="actionShow_menu"/>
     <addaction name="actionFullscreen"/>
@@ -559,6 +559,15 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
    <addaction name="actionNext"/>
   </widget>
   <widget class="QDockWidget" name="dockWidgetLyrics">
+   <property name="minimumSize">
+    <size>
+     <width>250</width>
+     <height>87</height>
+    </size>
+   </property>
+   <property name="features">
+    <set>QDockWidget::AllDockWidgetFeatures</set>
+   </property>
    <property name="windowTitle">
     <string>&amp;Lyrics</string>
    </property>
@@ -789,10 +798,11 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset theme="view-media-lyrics"/>
+    <iconset theme="view-media-lyrics">
+     <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
-    <string>Show lyrics</string>
+    <string>Show &amp;lyrics</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>

--- a/app/forms/mainwindow.ui
+++ b/app/forms/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>933</width>
+    <width>1113</width>
     <height>712</height>
    </rect>
   </property>
@@ -471,8 +471,8 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>933</width>
-     <height>22</height>
+     <width>1113</width>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuApplication">
@@ -510,6 +510,7 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
     </property>
     <addaction name="actionShow_menu"/>
     <addaction name="actionFullscreen"/>
+    <addaction name="actionShow_lyrics"/>
    </widget>
    <widget class="QMenu" name="menuNavigation">
     <property name="title">
@@ -556,6 +557,31 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
    <addaction name="actionPrevious"/>
    <addaction name="actionPlayPause"/>
    <addaction name="actionNext"/>
+  </widget>
+  <widget class="QDockWidget" name="dockWidgetLyrics">
+   <property name="windowTitle">
+    <string>&amp;Lyrics</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="0">
+      <widget class="QTextEdit" name="textEditLyrics">
+       <property name="undoRedoEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QTextEdit::WidgetWidth</enum>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
   </widget>
   <action name="actionSelect_service">
    <property name="icon">
@@ -756,6 +782,20 @@ QPushButton:hover,  QPushButton:pressed, QPushButton:focus {
    </property>
    <property name="shortcut">
     <string>F4</string>
+   </property>
+  </action>
+  <action name="actionShow_lyrics">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="view-media-lyrics"/>
+   </property>
+   <property name="text">
+    <string>Show lyrics</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
    </property>
   </action>
  </widget>

--- a/app/include/controllers/lyrics.h
+++ b/app/include/controllers/lyrics.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+//
+// This file is part of MellowPlayer.
+//
+// MellowPlayer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// MellowPlayer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with MellowPlayer.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+#ifndef LYRICSCONTROLLER_H
+#define LYRICSCONTROLLER_H
+
+//---------------------------------------------------------
+// Headers
+//---------------------------------------------------------
+#include <QtNetwork>
+#include "controllers/base.h"
+#include "utils/songinfo.h"
+
+//---------------------------------------------------------
+// Forward declarations
+//---------------------------------------------------------
+class MainWindow;
+
+class LyricsController : public BaseController {
+  Q_OBJECT
+public:
+  explicit LyricsController(MainWindow *parent = 0);
+
+//  void restoreLyricsPaneState();
+  void saveState();
+
+//  void isAutoShowEnabled();
+//  void setAutoShowEnabled();
+
+signals:
+
+public slots:
+    void showLyricsPane(bool show);
+    void onPageChanged(int page);
+    void onSongChanged(const SongInfo &songInfo);
+    void onLyricsLoaded(QNetworkReply *reply);
+
+private:
+    QNetworkAccessManager *m_nam;
+};
+
+#endif // HOTKEYSCONTROLLER_H

--- a/app/src/controllers/lyrics.cpp
+++ b/app/src/controllers/lyrics.cpp
@@ -1,0 +1,135 @@
+//-----------------------------------------------------------------------------
+//
+// This file is part of MellowPlayer.
+//
+// MellowPlayer is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// MellowPlayer is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with MellowPlayer.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------
+// Headers
+//---------------------------------------------------------
+#include <QAction>
+#include <QDomDocument>
+#include <qxtglobalshortcut.h>
+#include "controllers/lyrics.h"
+#include "controllers/player.h"
+#include "views/mainwindow.h"
+#include "ui_mainwindow.h"
+
+
+#define LYRICS_ENGINE_URL "http://api.chartlyrics.com/apiv1.asmx/SearchLyricDirect?artist=%1&song=%2"
+
+//---------------------------------------------------------
+// Implementations
+//---------------------------------------------------------
+//-------------------------------------
+LyricsController::LyricsController(MainWindow *parent)
+    : BaseController("lyrics", parent) {
+
+    m_nam  = new QNetworkAccessManager(this);
+    connect(m_mainWindow->ui()->actionShow_lyrics, &QAction::toggled, this, &LyricsController::showLyricsPane);
+    connect(m_mainWindow->ui()->stackedWidget, &QStackedWidget::currentChanged, this, &LyricsController::onPageChanged);
+    connect(m_mainWindow->player(), &PlayerController::songChanged, this, &LyricsController::onSongChanged);
+    connect(m_nam, &QNetworkAccessManager::finished, this, &LyricsController::onLyricsLoaded);
+    showLyricsPane(false);
+
+    m_mainWindow->ui()->textEditLyrics->setAlignment(Qt::AlignCenter);
+}
+
+//-------------------------------------
+void LyricsController::saveState()
+{
+    QSettings().setValue("lyricsPaneVisible", m_mainWindow->ui()->dockWidgetLyrics->isVisible());
+}
+
+//-------------------------------------
+void LyricsController::showLyricsPane(bool show)
+{
+    m_mainWindow->ui()->actionShow_lyrics->blockSignals(true);
+    m_mainWindow->ui()->actionShow_lyrics->setChecked(show);
+    m_mainWindow->ui()->actionShow_lyrics->blockSignals(false);
+
+    m_mainWindow->ui()->dockWidgetLyrics->setVisible(show);
+}
+
+//-------------------------------------
+void LyricsController::onPageChanged(int page)
+{
+    if(page == PAGE_WEB){
+        // restore state of lyrics pane
+        bool autoShow = QSettings().value("automaticallyShowLyricsPane", true).toBool();
+        bool lyricsPaneVisible = QSettings().value("lyricsPaneVisible", false).toBool();
+        if(!autoShow){
+            m_mainWindow->ui()->dockWidgetLyrics->setVisible(lyricsPaneVisible);
+        }
+    } else {
+        showLyricsPane(false);
+    }
+}
+
+//-------------------------------------
+void LyricsController::onSongChanged(const SongInfo &songInfo)
+{
+    QString baseUrl(LYRICS_ENGINE_URL);
+    QString artist = QString(songInfo.ArtistName).toLower();
+    QString song = QString(songInfo.SongTitle).toLower();
+
+    // replace stop words (see http://www.chartlyrics.com/api.aspx STOP WORDS)
+    // french words
+    QRegExp frenchStopWords("\\s?(le|la|les|du|des|de|chanson|encore|autre|ici|là|mauvaise)\\s+");
+//    while(frenchStopWords.indexIn(song) != -1)
+    song = song.replace(frenchStopWords, " ");
+
+    qDebug() << "Song" << song;
+
+
+    QString url = baseUrl.arg(artist).arg(song);
+
+    m_mainWindow->ui()->textEditLyrics->clear();
+    m_mainWindow->ui()->textEditLyrics->setAlignment(Qt::AlignCenter);
+
+
+    m_nam->get(QNetworkRequest(url));
+    qDebug() << "Lyrics URL: " << url;
+}
+
+//-------------------------------------
+void LyricsController::onLyricsLoaded(QNetworkReply* reply)
+{
+    bool found = false;
+    QString lyrics = tr("Lyrics not found");
+    QByteArray data = reply->readAll();
+
+    QDomDocument doc;
+    doc.setContent(data);
+    QDomElement root = doc.documentElement();
+    QDomNodeList children = root.childNodes();
+    for(int i = 0; i < children.count(); ++i){
+        QDomElement elem = children.at(i).toElement();
+        if(elem.tagName() == "Lyric"){
+            if(!elem.text().isEmpty()) {
+                lyrics = elem.text();
+                found = true;
+            }
+        }
+    }
+    bool autoShow = QSettings().value("automaticallyShowLyricsPane", true).toBool();
+
+    m_mainWindow->ui()->textEditLyrics->setText("<p>" + lyrics.replace("\n", "<br>") + "</p>");
+    m_mainWindow->ui()->textEditLyrics->setAlignment(Qt::AlignCenter);
+    if(autoShow){
+        m_mainWindow->ui()->dockWidgetLyrics->setVisible(found);
+    }
+}

--- a/app/src/views/dlgpreferences.cpp
+++ b/app/src/views/dlgpreferences.cpp
@@ -173,12 +173,14 @@ void DlgPreferences::resetInterface() {
   bool showTrayIcon =
       QSettings().value("interface/showTrayIcon", QVariant(true)).toBool();
   QString trayIconPath = QSettings().value("interface/trayIcon").toString();
+  bool autoShowLyrics = QSettings().value("interface/automaticallyShowLyricsPane", false).toBool();
   bool confirmQuit = QSettings().value("interface/confirmQuit", true).toBool();
 
   m_ui->checkBoxConfirmQuit->setChecked(confirmQuit);
   m_ui->checkBoxShowTrayIcon->setChecked(showTrayIcon);
   m_ui->groupBoxMinimizeToTray->setChecked(minimizeToTray);
   m_ui->lineEditTrayIcon->setText(trayIconPath);
+  m_ui->checkBoxAutoShowLyrics->setChecked(autoShowLyrics);
   updateTrayIconPreview(trayIconPath);
 }
 
@@ -231,6 +233,7 @@ void DlgPreferences::restoreInterface() {
   QSettings().setValue("interface/showTrayIcon", true);
   QSettings().setValue("interface/trayIcon", "");
   QSettings().setValue("interface/confirmQuit", true);
+  QSettings().setValue("interface/automaticallyShowLyricsPane", false);
 
   resetInterface();
 }
@@ -274,6 +277,8 @@ void DlgPreferences::applyInterface() {
                        m_ui->checkBoxShowTrayIcon->isChecked());
   QSettings().setValue("interface/confirmQuit",
                        m_ui->checkBoxConfirmQuit->isChecked());
+  QSettings().setValue("interface/automaticallyShowLyricsPane",
+                       m_ui->checkBoxAutoShowLyrics->isChecked());
   QSettings().setValue("interface/trayIcon", m_ui->lineEditTrayIcon->text());
 }
 

--- a/app/src/views/mainwindow.cpp
+++ b/app/src/views/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include <QWebEnginePage>
 #include <QWebEngineSettings>
 #include "controllers/hotkeys.h"
+#include "controllers/lyrics.h"
 #include "controllers/mpris2.h"
 #include "controllers/notifications.h"
 #include "controllers/player.h"
@@ -69,6 +70,7 @@ MainWindow::MainWindow(QWidget *parent)
   new NotificationsController(this);
   new HotkeysController(this);
   new MPRIS2Controller(this);
+  new LyricsController(this);
 }
 
 //-------------------------------------
@@ -112,6 +114,8 @@ void MainWindow::closeEvent(QCloseEvent *event) {
     hide();
     event->ignore();
   } else {
+    LyricsController* lyrics = qobject_cast<LyricsController*>(controller("lyrics"));
+    lyrics->saveState();
     player()->stopPolling();
     hide();
     qApp->processEvents();
@@ -329,6 +333,8 @@ bool MainWindow::exitApplication() {
     if (answer == QMessageBox::No)
       return false;
   }
+  LyricsController* lyrics = qobject_cast<LyricsController*>(controller("lyrics"));
+  lyrics->saveState();
   qApp->exit();
   return true;
 }
@@ -489,8 +495,10 @@ void MainWindow::setupToolbar() {
   m_BtMenu->setPopupMode(QToolButton::InstantPopup);
   m_BtMenu->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
   QMenu *mnu = new QMenu(tr("Control"), m_BtMenu);
-  mnu->addAction(m_ui->actionShow_menu);
-  mnu->addAction(m_ui->actionFullscreen);
+  QMenu* viewMenu = mnu->addMenu("View");
+  viewMenu->addAction(m_ui->actionShow_menu);
+  viewMenu->addAction(m_ui->actionFullscreen);
+  viewMenu->addAction(m_ui->actionShow_lyrics);
   mnu->addSeparator();
   mnu->addAction(m_ui->actionCreate_plugin);
   mnu->addSeparator();

--- a/mellowplayer.pro
+++ b/mellowplayer.pro
@@ -25,7 +25,7 @@ else {
     TARGET = MellowPlayer
 }
 TEMPLATE = app
-QT += core gui network widgets webengine webenginewidgets
+QT += core gui network widgets webengine webenginewidgets xml
 !macx {
     QT += LibsnoreQt5
 }
@@ -67,6 +67,7 @@ SOURCES += main.cpp\
            application.cpp \
            controllers/base.cpp \
            controllers/hotkeys.cpp \
+           controllers/lyrics.cpp \
            controllers/notifications.cpp \
            controllers/mpris2.cpp \
            controllers/player.cpp \
@@ -84,8 +85,9 @@ SOURCES += main.cpp\
            views/wizard_new_plugin.cpp
 
 HEADERS += application.h \
-           controllers/hotkeys.h \
            controllers/base.h \
+           controllers/hotkeys.h \
+           controllers/lyrics.h \
            controllers/mpris2.h \
            controllers/notifications.h \
            controllers/player.h \


### PR DESCRIPTION
We use the [chartlyrics http API](http://www.chartlyrics.com/api.aspx) to retrieve lyrics, it does not have all lyrics and sometimes lead to wrong lyrics but it is the best free service I could find (most services listed on [programmable web](http://www.programmableweb.com/category/lyrics/apis?category=20278) are either discontinued or not stable).

The lyrics pane is hidden by default. It can be show by toggling ``View->Show Lyrics`` or *Ctrl+L*. There is also an option to show the pane automatically if lyrics can be found, this option is off by default (``Preferences->Interface->Automatically show lyrics pane``)

Here is a screenshot:

![screenshot_20160622_095405](https://cloud.githubusercontent.com/assets/1681217/16263325/1eb32a56-3874-11e6-8f40-c9ec3ef4539a.png)

