### PR TITLE
GPM: improve playback status detection

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,3 +11,4 @@ Contributors
 - [ZeroDot1](http://basic1.moy.su/)
 - [Lukas Kolletzki](https://github.com/kolletzki)
 - [Mahmoud Hossam](https://github.com/mahmoudhossam)
+- [Terin Stock](https://github.com/terinjokes)

--- a/plugins/googleplaymusic/integration.js
+++ b/plugins/googleplaymusic/integration.js
@@ -32,11 +32,14 @@ function getButtons() {
 // Much of this was adapted from: https://github.com/tiliado/nuvola-app-google-play-music
 //-----------------------------------------------------------------------------
 function update() {
-    var controlClassName = document.querySelector("#player div.material-player-middle").children[3].className;
-    var playbackStatus = mellowplayer.PlaybackStatus.STOPPED;
-    if (controlClassName === "x-scope paper-icon-button-0 playing")
+    var pp = getButtons().playpause;
+    var playbackStatus;
+
+    if (pp.disabled)
+        playbackStatus = mellowplayer.PlaybackStatus.STOPPED;
+    else if (pp.className.indexOf("playing") != -1)
         playbackStatus = mellowplayer.PlaybackStatus.PLAYING;
-    else if (controlClassName === "x-scope paper-icon-button-0")
+    else
         playbackStatus = mellowplayer.PlaybackStatus.PAUSED;
 
     var elm;


### PR DESCRIPTION
Improve the detection of the current playback status by looking for the
disabled vs enabled state of the play-pause button, and for the
"playing" class name.

Google Play Music seems to have migrated away from "paper-icon-button-0"
preventing the previous method from working.