### PR TITLE
GPM - handle cases when we can't go to next/previous

### DIFF
--- a/src/plugins/web/googleplaymusic/integration.js
+++ b/src/plugins/web/googleplaymusic/integration.js
@@ -131,6 +131,12 @@ function update() {
         position = parseInt(pseconds, 10) + (parseInt(pminutes, 10) * 60);
     } catch (e) {}
 
+    elm = getButtons().skip;
+    var canGoNext = elm != null && !elm.disabled;
+
+    elm = getButtons().back;
+    var canGoPrevious = elm != null && !elm.disabled;
+
     var canSeek = getButtons().seekBar != null && duration != 0;
 
     // Adapted from gmusic.js
@@ -149,8 +155,8 @@ function update() {
     return {
         "playbackStatus": playbackStatus,
         "canSeek": canSeek,
-        "canGoNext": true,
-        "canGoPrevious": true,
+        "canGoNext": canGoNext,
+        "canGoPrevious": canGoPrevious,
         "canAddToFavorites": canAddToFavorites,
         "volume": 1,
         "duration": duration,


### PR DESCRIPTION
## Proposed Changes
GPM Plugin - properly handle cases when we can't go to next/previous.

Example: when repeat is disabled and the last track in the queue finishes playing GPM disables next and previous buttons and clicking on them does nothing (play button still works).

MellowPlayer should handle such cases correctly so that it does not display active next and previous buttons in it's toolbar/MPRIS applet when it can't actually skip to next/previous  song
