### PR TITLE
Youtube plugin Fix.

### DIFF
--- a/src/plugins/web/youtube/integration.js
+++ b/src/plugins/web/youtube/integration.js
@@ -44,6 +44,21 @@ function update() {
 
     player = document.getElementById("movie_player");
 
+    // An ad is currently played
+    var adContainer = document.getElementsByClassName('videoAdUiSkipContainer')[0];
+    if( adContainer ) {
+
+        // If the ad can't be skipped, the sound is muted
+        if( adContainer.style.display == "none" ) {
+            player.mute();
+
+        // If the ad can be skipped, the sound is unmuted and the ad skipped
+        } else if( document.getElementsByClassName('videoAdUiSkipButton')[0] ) {
+            document.getElementsByClassName('videoAdUiSkipButton')[0].click();
+            player.unMute();
+        }
+    }
+
     // Playback status
     switch(player.getPlayerState()) {
         case 1:

--- a/src/plugins/web/youtube/integration.js
+++ b/src/plugins/web/youtube/integration.js
@@ -16,13 +16,33 @@
 // along with MellowPlayer.  If not, see <http://www.gnu.org/licenses/>.
 //
 //-----------------------------------------------------------------------------
+
 var player;
 
 function update() {
 
-    // Get the player when available once
-    if(!player)
-        player = document.getElementById("movie_player");
+    // If the player is not currently playing a video
+    if(!document.getElementsByTagName('ytd-app')[0].attributes['is-watch-page']) {
+        return {
+            "playbackStatus": mellowplayer.PlaybackStatus.STOPPED,
+            "volume": 0,
+            "duration": 0,
+            "position": 0,
+            "songId": 0,
+            "songTitle": "",
+            "artistName": "",
+            "artUrl": "",
+            "canSeek": false,
+            "canGoNext": false,
+            "canGoPrevious": false,
+
+            "albumTitle": "",
+            "canAddToFavorites": false,
+            "isFavorite": false
+        };
+    }
+
+    player = document.getElementById("movie_player");
 
     // Playback status
     switch(player.getPlayerState()) {
@@ -62,7 +82,9 @@ function update() {
         "artUrl": artUrl,
         "canSeek": true,
         "canGoNext": true,
-        "canGoPrevious": true,
+
+        // Check if the video is in a playlist
+        "canGoPrevious": document.getElementById('playlist-actions') ? true : false,
 
         "albumTitle": "",
         "canAddToFavorites": false,


### PR DESCRIPTION
## Fixes 
Fix the youtube persistent information. Disable the preview button when the player is outside a playlist.
Fix #218 Add the ads control. It will mute during the ad and skip it automatically.
