### PR TITLE
Fixing TIDAL and Listening History

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@ Contributors
 - [Rasmus Thomsen](https://github.com/Cogitri)
 - [DmMlhch](https://github.com/DmMlhch)
 - [Rustam Zhumagambetov](https://github.com/rustamzh)
+- [Nagy Tamás (T-bond)](https://github.com/T-bond)

--- a/src/lib/presentation/resources/mellowplayer.js
+++ b/src/lib/presentation/resources/mellowplayer.js
@@ -7,7 +7,8 @@ MellowPlayer = {
         if (MellowPlayer.ready && MellowPlayer.player.isRunning) {
             var updateResults = update();
             try {
-                updateResults.songId = getHashCode(updateResults.songTitle);
+                if(updateResults.songId == 0)
+                    updateResults.songId = getHashCode(updateResults.songTitle);
             } catch (e) {
                 updateResults.songId = -1;
             }

--- a/src/plugins/web/tidal/integration.js
+++ b/src/plugins/web/tidal/integration.js
@@ -1,7 +1,6 @@
 var previousID = -1;
 
-function getItemByTestID(buttonName, parent)
-{
+function getItemByTestID(buttonName, parent) {
     parent = parent || document;
     return parent.querySelectorAll("[data-test-id=\""+buttonName+"\"]")[0];
 }
@@ -10,8 +9,7 @@ function isPaused() {
     return getItemByTestID("play");
 }
 
-function getAlbumTitle()
-{
+function getAlbumTitle() {
     var links = document.getElementsByClassName("infoTable--22VxO")[0].getElementsByTagName('a');
     for(var link = 0; link < links.length; link++)
         if(links[link].href.indexOf("/album/") !== -1)
@@ -100,9 +98,12 @@ function update() {
         
         // We skip the default album image placeholder, it loads before the first album loads, so on start there won't
         // be a album on MPRIS as it will be cached for the first loaded song, also it doesn't show up as it is svg
+        if(results.artUrl.indexOf("defaultAlbumImage.78c633.svg") !== -1)
+            results.artUrl = "";
+
         // also don't allow to load the art if we still hasn't started buffering.
         // We drop the status about the song until we find the art, so it won't create multiple item in the listening history
-        if(results.artUrl.indexOf("defaultAlbumImage.78c633.svg") !== -1 || results.songId != previousID || results.playbackStatus == mellowplayer.PlaybackStatus.BUFFERING) {
+        if(results.songId != previousID || results.playbackStatus == mellowplayer.PlaybackStatus.BUFFERING) {
             results.songTitle = "";
             results.songId = 0;
             results.artUrl = "";
@@ -116,7 +117,7 @@ function update() {
         // If it is paused, we use the seekbar's value, as if we seek, only that will be updated
         results.position = isPaused() ? getItemByTestID("progress-bar", infoDiv).getAttribute("aria-valuenow") : toSeconds(getItemByTestID("duration", infoDiv).children[0].innerHTML);
         results.duration = toSeconds(getItemByTestID("duration", infoDiv).children[1].innerHTML);
-        results.volume = infoDiv.getElementsByClassName("nativeRange--EDim6")[0].value;
+        results.volume = infoDiv.getElementsByClassName("nativeRange--EDim6")[0].value / 100;
         results.isFavorite = infoDiv.getElementsByClassName("mediaActions--3gVRx")[0].getElementsByClassName("button--1GSBa")[0].classList.contains("favorite--3ptX1");
         results.albumTitle = getAlbumTitle();
         results.canSeek = true;
@@ -142,8 +143,16 @@ function goPrevious() {
     getItemByTestID("previous").click();
 }
 
-function setVolume(volume) {   
-    sendMouseClickToElement(getItemByTestID("footer-player").getElementsByClassName("nativeRange--EDim6")[0], volume, 0.5);   
+function setVolume(volume) {
+    if(volume == 0)
+        getItemByTestID("volume", getItemByTestID("footer-player")).click();
+    else{
+        var volumeSlider = getItemByTestID("footer-player").getElementsByClassName("nativeRange--EDim6")[0];
+        volumeSlider.value = volume * 100;
+        volumeSlider.dispatchEvent(new Event('input', {
+            'bubbles': true
+        }));
+    }
 }
 
 function addToFavorites() {

--- a/src/plugins/web/tidal/integration.js
+++ b/src/plugins/web/tidal/integration.js
@@ -86,10 +86,7 @@ function update() {
             previousID = results.songId;
         }
         
-        // Replacing HTTPS to HTTP, as it gives OpenSSL errors and doesn't download the image.
-        /// TODO: It should be fixed, and reverted back to HTTPS, as know someone on the network can see what album
-        /// is being played
-        results.artUrl = getItemByTestID("current-media-imagery", infoDiv).children[0].src.replace("https", "http");
+        results.artUrl = getItemByTestID("current-media-imagery", infoDiv).children[0].src;
         
         // On the initial song, there is no buffering, so we can accept the first valid album art
         if(previousID == -1)

--- a/src/plugins/web/tidal/integration.js
+++ b/src/plugins/web/tidal/integration.js
@@ -1,24 +1,64 @@
-function getButtons() {
-    return {
-        "pause": document.getElementsByClassName("play-controls__pause")[0],
-        "play": document.getElementsByClassName("play-controls__play")[0],
-        "next": document.getElementsByClassName("play-controls__next")[0],
-        "previous": document.getElementsByClassName("play-controls__previous")[0],
-        "main": document.getElementsByClassName("play-controls__main-button")[0]
-    }
+var previousID = -1;
+
+function getItemByTestID(buttonName, parent)
+{
+    parent = parent || document;
+    return parent.querySelectorAll("[data-test-id=\""+buttonName+"\"]")[0];
 }
 
 function isPaused() {
-    return document.getElementsByClassName("play-controls__main-button--paused").length !== 0;
+    return getItemByTestID("play");
 }
 
-function isPlayerVisible() {
-    return document.getElementsByClassName("player--audio").length > 0;
+function getAlbumTitle()
+{
+    var links = document.getElementsByClassName("infoTable--22VxO")[0].getElementsByTagName('a');
+    for(var link = 0; link < links.length; link++)
+        if(links[link].href.indexOf("/album/") !== -1)
+            return links[link].innerHTML;
+    return "";
+}
+
+// The two functions below can be used to control playback position and volume level
+// See https://www.martin-brennan.com/simulating-mouse-click-event-javascript/ , 
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+// and https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent for details
+/**
+ * @param element    (HTMLElement) Element to send events to. 
+ * @param eventName  (String) type of the MouseEvent to send. 
+ * @param relativeX  (Float) relative x position within the boundaries of the element, 
+ * as a fraction of the element's width(0..1). 
+ * @param relativeY  (Float) relative y position within the boundaries of the element,
+ * as a fraction of the element's height(0..1).
+*/
+function sendMouseEventToElement(element, eventName, relativeX, relativeY) {
+    var clientRect = element.getBoundingClientRect();   
+    var event = new MouseEvent(eventName, {
+        'view': window,
+        'bubbles': true,
+        'cancelable': true,
+        'clientX': clientRect.left + (clientRect.width * relativeX),
+        'clientY': clientRect.top + (clientRect.height * relativeY)
+    });
+    element.dispatchEvent(event);
+}
+/**
+ * Emulates mouse click on the specified position of the given element
+ * @param element    (HTMLElement) Element to send click to. 
+ * @param relativeX  (Float) relative x position within the boundaries of the element, 
+ * as a fraction of the element's width(0..1). 
+ * @param relativeY  (Float) relative y position within the boundaries of the element,
+ * as a fraction of the element's height(0..1).
+*/
+function sendMouseClickToElement(element, relativeX, relativeY) {
+    sendMouseEventToElement(element, 'mouseenter', relativeX, relativeY);
+    sendMouseEventToElement(element, 'mousedown', relativeX, relativeY);
+    sendMouseEventToElement(element, 'click', relativeX, relativeY);
+    sendMouseEventToElement(element, 'mouseup', relativeX, relativeY);
+    sendMouseEventToElement(element, 'mouseleave', relativeX, relativeY);
 }
 
 function update() {
-    console.error("up");
-
     var results = {
         "playbackStatus": mellowplayer.PlaybackStatus.STOPPED,
         "canSeek": false,
@@ -36,51 +76,85 @@ function update() {
         "isFavorite": false
     };
 
-    if (isPlayerVisible()) {
-        var playerInfoDiv = document.getElementsByClassName("player")[0].children[1].children[0];
-
+    // If player is loaded
+    if(getItemByTestID("footer-player")) {
+        var infoDiv = getItemByTestID("footer-player");
+        results.songTitle = getItemByTestID("footer-track-title", infoDiv).children[0].innerHTML;
+        results.songId = getHashCode(getItemByTestID("footer-track-title", infoDiv).children[0].href);
+        
         results.playbackStatus = isPaused() ? mellowplayer.PlaybackStatus.PAUSED : mellowplayer.PlaybackStatus.PLAYING;
-        results.canGoNext = !getButtons().next.disabled;
-        results.canGoPrevious = !getButtons().previous.disabled;
-        results.songTitle = playerInfoDiv.children[1].children[0].text;
-        results.artistName = playerInfoDiv.children[1].children[1].textContent;
-        results.songId = getHashCode(results.songTitle);
-        results.duration = toSeconds(document.getElementsByClassName("js-duration")[0].lastChild.nodeValue);
-        results.position = toSeconds(document.getElementsByClassName("js-progress")[0].lastChild.nodeValue);
-        results.artUrl = playerInfoDiv.children[0].children[1].children[0].src;
-    }
+        if(window.getComputedStyle(getItemByTestID("loading-indicator", infoDiv)).getPropertyValue("display") !== "none") {
+            results.playbackStatus = mellowplayer.PlaybackStatus.BUFFERING;
+            previousID = results.songId;
+        }
+        
+        // Replacing HTTPS to HTTP, as it gives OpenSSL errors and doesn't download the image.
+        /// TODO: It should be fixed, and reverted back to HTTPS, as know someone on the network can see what album
+        /// is being played
+        results.artUrl = getItemByTestID("current-media-imagery", infoDiv).children[0].src.replace("https", "http");
+        
+        // On the initial song, there is no buffering, so we can accept the first valid album art
+        if(previousID == -1)
+            previousID = results.songId;
+        
+        
+        // We skip the default album image placeholder, it loads before the first album loads, so on start there won't
+        // be a album on MPRIS as it will be cached for the first loaded song, also it doesn't show up as it is svg
+        // also don't allow to load the art if we still hasn't started buffering.
+        // We drop the status about the song until we find the art, so it won't create multiple item in the listening history
+        if(results.artUrl.indexOf("defaultAlbumImage.78c633.svg") !== -1 || results.songId != previousID || results.playbackStatus == mellowplayer.PlaybackStatus.BUFFERING) {
+            results.songTitle = "";
+            results.songId = 0;
+            results.artUrl = "";
+            
+            return results;
+        }
 
+        results.canGoNext = !getItemByTestID("next", infoDiv).disabled;
+        results.canGoPrevious = !getItemByTestID("previous", infoDiv).disabled;
+        results.artistName = getItemByTestID("grid-item-detail-text-title-artist", infoDiv).innerHTML;
+        // If it is paused, we use the seekbar's value, as if we seek, only that will be updated
+        results.position = isPaused() ? getItemByTestID("progress-bar", infoDiv).getAttribute("aria-valuenow") : toSeconds(getItemByTestID("duration", infoDiv).children[0].innerHTML);
+        results.duration = toSeconds(getItemByTestID("duration", infoDiv).children[1].innerHTML);
+        results.volume = infoDiv.getElementsByClassName("nativeRange--EDim6")[0].value;
+        results.isFavorite = infoDiv.getElementsByClassName("mediaActions--3gVRx")[0].getElementsByClassName("button--1GSBa")[0].classList.contains("favorite--3ptX1");
+        results.albumTitle = getAlbumTitle();
+        results.canSeek = true;
+        results.canAddToFavorites = true;
+    }
+    
     return results;
 }
 
 function play() {
-    getButtons().play.click();
+    getItemByTestID("play").click();
 }
 
 function pause() {
-    getButtons().pause.click();
+    getItemByTestID("pause").click();
 }
 
 function goNext() {
-    getButtons().next.click();
+    getItemByTestID("next").click();
 }
 
 function goPrevious() {
-    getButtons().previous.click();
+    getItemByTestID("previous").click();
 }
 
-function setVolume(volume) {
-
+function setVolume(volume) {   
+    sendMouseClickToElement(getItemByTestID("footer-player").getElementsByClassName("nativeRange--EDim6")[0], volume, 0.5);   
 }
 
 function addToFavorites() {
-
+    getItemByTestID("footer-player").getElementsByClassName("mediaActions--3gVRx")[0].getElementsByClassName("button--1GSBa")[0].click();
 }
 
 function removeFromFavorites() {
-
+    addToFavorites();
 }
 
 function seekToPosition(position) {
-
+    var positionAsFraction = position / update().duration;   
+    sendMouseClickToElement(getItemByTestID("interaction-layer", getItemByTestID("footer-player")), positionAsFraction, 0.5);   
 }

--- a/src/plugins/web/tidal/metadata.ini
+++ b/src/plugins/web/tidal/metadata.ini
@@ -1,7 +1,7 @@
-author=Colin Duquesnoy
-author_website=https://github.com/ColinDuquesnoy
+author=T-bond
+author_website=https://t-bond.hu
 icon=logo.svg
 name=Tidal
 supported_platforms=All
 url=https://listen.tidal.com/
-version=1.0
+version=1.1


### PR DESCRIPTION
Fixes TIDAL and Listening History

## Proposed Changes

  - Removed the forced ID creation for songs. The reason was that it was created from the song name, so if I played two song with the same name, the Listening History started to produce them infinitely. (Tested on Deezer and TIDAL, before and after the fix)
  - Completely rewritten the TIDAL service, as it was not functional. Now it has every feature that I found missing. (Play / pause, next / previous tracks, volume settings, favourite song option, seeking, and getting all the metadata: song title, id, position, length, album art, album title, author)

I don't know how the volume settings should be tested, as I am started using MellowPlayer yesterday, and don't know where should it be changed.

Also I found that I can't load images over HTTPS, so redirecting every album art request through HTTP. It need to change, as it is not secure.
I'm using Debian Buster, and had the openssl1.1.1 package. Maybe it is too new for the project settings.

The error is: (and maybe I should fire an issue for it)
`[W] [2018-10-18 23-21-57:402093] [qt.network.ssl] QSslSocket: cannot call unresolved function SSLv23_client_method
[W] [2018-10-18 23-21-57:402325] [qt.network.ssl] QSslSocket: cannot call unresolved function SSL_CTX_new
[W] [2018-10-18 23-21-57:402361] [qt.network.ssl] QSslSocket: cannot call unresolved function SSL_library_init
[W] [2018-10-18 23-21-57:402387] [qt.network.ssl] QSslSocket: cannot call unresolved function ERR_get_error
[W] [2018-10-18 23-21-57:402635] [qt.network.ssl] QSslSocket: cannot call unresolved function ERR_get_error
[D] [2018-10-18 23-21-57:407346] [FileDownloader] download failed: Error creating SSL context ()`

Thanks:
    Nagy Tamás (T-bond)
